### PR TITLE
fix: add readiness and liveness probes to prevent ingress 502 errors (#3)

### DIFF
--- a/kubernetes/finance/deployment.yaml
+++ b/kubernetes/finance/deployment.yaml
@@ -33,3 +33,29 @@ spec:
           limits:
             cpu: "500m"
             memory: "512Mi"
+        
+        startupProbe:
+          httpGet:
+            path: /health/ready
+            port: 80
+          failureThreshold: 30
+          periodSeconds: 5
+
+        readinessProbe:
+          httpGet:
+            path: /health/ready
+            port: 80
+          initialDelaySeconds: 10
+          periodSeconds: 5
+          timeoutSeconds: 2
+          failureThreshold: 3
+          successThreshold: 1
+
+        livenessProbe:
+          httpGet:
+            path: /health/live
+            port: 80
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          timeoutSeconds: 2
+          failureThreshold: 3

--- a/kubernetes/inventory/deployment.yaml
+++ b/kubernetes/inventory/deployment.yaml
@@ -33,3 +33,29 @@ spec:
           limits:
             cpu: "500m"
             memory: "512Mi"
+        startupProbe:
+          httpGet:
+            path: /health/ready
+            port: 80
+          failureThreshold: 30
+          periodSeconds: 5
+
+        readinessProbe:
+          httpGet:
+            path: /health/ready
+            port: 80
+          initialDelaySeconds: 10
+          periodSeconds: 5
+          timeoutSeconds: 2
+          failureThreshold: 3
+          successThreshold: 1
+
+        livenessProbe:
+          httpGet:
+            path: /health/live
+            port: 80
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          timeoutSeconds: 2
+          failureThreshold: 3
+

--- a/kubernetes/school/deployment.yaml
+++ b/kubernetes/school/deployment.yaml
@@ -33,3 +33,29 @@ spec:
           limits:
             cpu: "500m"
             memory: "512Mi"
+
+        startupProbe:
+          httpGet:
+            path: /health/ready
+            port: 80
+          failureThreshold: 30
+          periodSeconds: 5
+
+        readinessProbe:
+          httpGet:
+            path: /health/ready
+            port: 80
+          initialDelaySeconds: 10
+          periodSeconds: 5
+          timeoutSeconds: 2
+          failureThreshold: 3
+          successThreshold: 1
+
+        livenessProbe:
+          httpGet:
+            path: /health/live
+            port: 80
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          timeoutSeconds: 2
+          failureThreshold: 3

--- a/kubernetes/vivahadeepam/deployment.yaml
+++ b/kubernetes/vivahadeepam/deployment.yaml
@@ -33,3 +33,29 @@ spec:
           limits:
             cpu: "500m"
             memory: "512Mi"
+
+        startupProbe:
+          httpGet:
+            path: /health/ready
+            port: 80
+          failureThreshold: 30
+          periodSeconds: 5
+
+        readinessProbe:
+          httpGet:
+            path: /health/ready
+            port: 80
+          initialDelaySeconds: 10
+          periodSeconds: 5
+          timeoutSeconds: 2
+          failureThreshold: 3
+          successThreshold: 1
+
+        livenessProbe:
+          httpGet:
+            path: /health/live
+            port: 80
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          timeoutSeconds: 2
+          failureThreshold: 3


### PR DESCRIPTION
### Summary
Added readiness and liveness probes to all microservices to ensure traffic is routed only to healthy pods.

### Changes
- Added readinessProbe to deployment.yaml
- Configured initialDelaySeconds and failureThreshold
- Updated Helm values (if applicable)

### Testing
- Verified no 502 errors during rollout
- Tested pod restart scenarios

### Related Issue
Closes #3