### PR TITLE
feat: configure S3 backend and DynamoDB locking for Terraform state (#11)

### DIFF
--- a/terraform/backend.tf
+++ b/terraform/backend.tf
@@ -1,0 +1,9 @@
+terraform {
+  backend "s3" {
+    bucket         = "dotnet-microservices-terraform-state"
+    key            = "eks/terraform.tfstate"
+    region         = "us-east-1"
+    dynamodb_table = "terraform-locks"
+    encrypt        = true
+  }
+}


### PR DESCRIPTION
### Summary
Implemented remote backend for Terraform state using AWS S3 and DynamoDB.

### Changes
- Added backend configuration to Terraform
- Created S3 bucket for state storage
- Configured DynamoDB table for locking

### Benefits
- Prevents state conflicts
- Enables team collaboration
- Improves reliability

### Related Issue
Closes #11